### PR TITLE
Fix 2 problem

### DIFF
--- a/src/ALMRunCommon.cpp
+++ b/src/ALMRunCommon.cpp
@@ -363,7 +363,8 @@ wxString GetPinYin(const wxString& source)
 		//一个区94个,位码 A1 - FE
 		if (H < 0xB0 ||  L < 0xA1 || H > 0xF7 || L == 0xFF)
 		{
-			pinyin.Append(H);
+			if(H < 0x80)
+				pinyin.Append(H);
 			continue;
 		}
 

--- a/src/MerryListBoxPanel.cpp
+++ b/src/MerryListBoxPanel.cpp
@@ -341,7 +341,7 @@ void MerryListBoxPanel::OnPaintEvent(wxPaintEvent& e)
 
 void MerryListBoxPanel::DrawBorder(MerryPaintDC& dc) const
 {
-	wxPoint p[4];
+	wxPoint p[5];
 	if (!border_width)
 		return;
 	int bw = border_width/2;
@@ -359,7 +359,8 @@ void MerryListBoxPanel::DrawBorder(MerryPaintDC& dc) const
 	p[3].x = p[1].x;
 	p[3].y = p[2].y;
 	p[4].y = p[2].y - item_height - border_width;
-	dc.SetPen(wxPen(skin->get(WINDOW_COLOR),border_width,skin->get(LIST_BORDER_STYLE)));
+	int twidth=border_width;
+	dc.SetPen(wxPen(skin->get(WINDOW_COLOR),twidth,skin->get(LIST_BORDER_STYLE)));
 	dc.DrawLine(p[0],p[1]);
 	dc.DrawLine(p[0],p[2]);
 	dc.DrawLine(p[1],p[3]);


### PR DESCRIPTION
该pull包含两个bug fix，一个是数组越界问题，一个是对于德文字符的判断修改。
在虚机的windows 8上试验，关机时并没有出现错误，无法重现内存错误，不清楚具体原因。